### PR TITLE
Release v4.4.0 Refactor client handling and improve notification logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 
 - PHP: 8.1+;
 - WHMCS: 8.6+
-- IonCube: 12+
 - Data Base SQL with permissions
   - ALTER
   - CREATE

--- a/src/modules/addons/lknhooknotification/lknhooknotification.php
+++ b/src/modules/addons/lknhooknotification/lknhooknotification.php
@@ -23,7 +23,7 @@ function lknhooknotification_config()
         $language = 'english';
     }
 
-    $version = '4.3.5'; // CHANGE MANUALLY ON RELEASE
+    $version = '4.4.0'; // CHANGE MANUALLY ON RELEASE
 
     return [
         'name' => lkn_hn_lang('WhatsApp and Chatwoot'),

--- a/src/modules/addons/lknhooknotification/src/Core/BulkMessaging/Application/Services/BulkService.php
+++ b/src/modules/addons/lknhooknotification/src/Core/BulkMessaging/Application/Services/BulkService.php
@@ -139,7 +139,7 @@ final class BulkService
 
     /**
      * @param  array<string, array<string>>|null $filters
-     * @param boolean                           $allClients
+     * @param boolean                            $allClients
      *
      * @return array
      */
@@ -153,7 +153,28 @@ final class BulkService
         }
 
         if (!empty($filters['client_locale'])) {
-            $query->whereIn('tblclients.language', $filters['client_locale']);
+            $locales = (array) $filters['client_locale'];
+            
+            $query->where(function ($q) use ($locales) {
+                $hasDefault = in_array('default', $locales, true) || in_array('', $locales, true);
+                
+                // CORREÇÃO: array_values aplicado para resetar as chaves do array filtrado
+                $explicitLocales = array_values(array_filter($locales, fn($val) => $val !== 'default' && $val !== ''));
+
+                if (!empty($explicitLocales)) {
+                    $q->whereIn('tblclients.language', $explicitLocales);
+                }
+
+                if ($hasDefault) {
+                    if (empty($explicitLocales)) {
+                         $q->whereNull('tblclients.language')
+                           ->orWhere('tblclients.language', '');
+                    } else {
+                         $q->orWhereNull('tblclients.language')
+                           ->orWhere('tblclients.language', '');
+                    }
+                }
+            });
         }
 
         if (!empty($filters['client_status'])) {
@@ -218,8 +239,6 @@ final class BulkService
     {
         $rawBulk = $this->bulkRepository->getBulks();
 
-
-
         $bulks = [];
 
         foreach ($rawBulk as $rawBulk) {
@@ -246,12 +265,12 @@ final class BulkService
     /**
      * @param NewBulkRequest $newBulkRequest
      * @param array{
-     *     header-parameter?: string,
-     *     body-parameters: array<int, string>,
-     *     button-parameters: array<int, string>,
-     *     message-template-lang: string,
-     *     message-template: string,
-     *     header-format: string
+     * header-parameter?: string,
+     * body-parameters: array<int, string>,
+     * button-parameters: array<int, string>,
+     * message-template-lang: string,
+     * message-template: string,
+     * header-format: string
      * } $rawFormPost
      *
      * @return Result
@@ -308,7 +327,8 @@ final class BulkService
                 'Unable to queue bulk messages',
                 [
                     'new_bulk_request' => $newBulkRequest,
-                    'client_ids' => $clientIds,
+                    // CORREÇÃO: A linha 'client_ids' => $clientIds foi removida daqui, 
+                    // pois $clientIds não existe neste momento e causaria um Fatal Error.
                 ],
                 [
                     'bulk_id' => $bulkId,

--- a/src/modules/addons/lknhooknotification/src/Core/BulkMessaging/Http/Views/pages/edit_create_bulk.tpl
+++ b/src/modules/addons/lknhooknotification/src/Core/BulkMessaging/Http/Views/pages/edit_create_bulk.tpl
@@ -374,9 +374,20 @@
                                     multiple
                                     {if $page_params.mode === 'edit'}disabled{/if}
                                 >
+                                    {* INÍCIO DA ALTERAÇÃO (Agora com o || empty) *}
+                                    <option 
+                                        value="default"
+                                        {if (isset($page_params.state->filters['client_locale']) && in_array('default', $page_params.state->filters['client_locale'])) || empty($page_params.state->filters['client_locale'])}
+                                            selected
+                                        {/if}
+                                    >
+                                        {lkn_hn_lang text="Default"}
+                                    </option>
+                                    {* FIM DA ALTERAÇÃO *}
+
                                     {foreach from=$page_params.field_options.whmcs_client_lang item=$locale}
                                         <option
-                                            {if $page_params.state->filters['client_locale'] && in_array($locale['locale_expanded'], $page_params.state->filters['client_locale']) || empty($page_params.state->filters['client_locale'])}
+                                            {if (isset($page_params.state->filters['client_locale']) && in_array($locale['locale_expanded'], $page_params.state->filters['client_locale'])) || empty($page_params.state->filters['client_locale'])}
                                                 selected
                                             {/if}
                                             value="{$locale['locale_expanded']}"

--- a/src/modules/addons/lknhooknotification/src/Core/Notification/Domain/Client.php
+++ b/src/modules/addons/lknhooknotification/src/Core/Notification/Domain/Client.php
@@ -10,8 +10,9 @@ use WHMCS\Database\Capsule;
 
 final class Client
 {
-    public ?int $wpPhoneNumber = null;
-    public readonly ?int $whmcsPhoneNumber;
+    // FIX: Changed properties to accept strings
+    public ?string $wpPhoneNumber = null;
+    public readonly ?string $whmcsPhoneNumber;
     private readonly ClientRepository $clientRepository;
     public readonly string $locale;
 
@@ -28,17 +29,23 @@ final class Client
         $this->clientRepository = new ClientRepository();
 
         $whmcsPhoneNumber       = $this->clientRepository->getWhmcsPhoneNumber($this->id);
-        $this->whmcsPhoneNumber = $whmcsPhoneNumber ? ((int) preg_replace('/[^0-9+]/', '', $whmcsPhoneNumber)) : null;
+        // FIX: Removed (int) cast. Kept as string after regex.
+        $this->whmcsPhoneNumber = $whmcsPhoneNumber ? preg_replace('/[^0-9+]/', '', $whmcsPhoneNumber) : null;
+        
         $countryCode            = $this->clientRepository->getClientCountry($this->id);
 
         $this->countryCode = $countryCode;
         $this->locale      = $this->clientRepository->getClientLang($this->id)['locale'];
     }
 
-    public function validateWpPhoneNumber(int $customFieldId): false|int
+    // FIX: Return type is now false|string
+    public function validateWpPhoneNumber(int $customFieldId): false|string
     {
-        $wpPhoneNumber = (int) $this->clientRepository->getCustomField($this->id, $customFieldId);
-        $wpPhoneNumber = $wpPhoneNumber ? ((int) preg_replace('/[^0-9+]/', '', strval($wpPhoneNumber))) : null;
+        // FIX: Removed (int) cast when fetching the field. Keep it as string.
+        $wpPhoneNumberRaw = $this->clientRepository->getCustomField($this->id, $customFieldId);
+        
+        // FIX: Removed (int) cast.
+        $wpPhoneNumber = $wpPhoneNumberRaw ? preg_replace('/[^0-9+]/', '', strval($wpPhoneNumberRaw)) : null;
 
         if (!$wpPhoneNumber) {
             return false;
@@ -48,12 +55,12 @@ final class Client
             return false;
         }
 
-
         $this->wpPhoneNumber = $wpPhoneNumber;
         return $this->wpPhoneNumber;
     }
 
-    public function validateWhmcsPhoneNumber(): false|int
+    // FIX: Return type is now false|string
+    public function validateWhmcsPhoneNumber(): false|string
     {
         if (
             empty($this->whmcsPhoneNumber)
@@ -65,7 +72,8 @@ final class Client
         return $this->whmcsPhoneNumber;
     }
 
-    public function getWpPhoneNumberOrWhmcsPhoneNumber(?int $platformSpecificWpCustomFieldId): false|int
+    // FIX: Return type is now false|string
+    public function getWpPhoneNumberOrWhmcsPhoneNumber(?int $platformSpecificWpCustomFieldId): false|string
     {
         /** @var null|int $globalWpCustomFieldId */
         $globalWpCustomFieldId = lkn_hn_config(Settings::WP_CUSTOM_FIELD_ID);
@@ -84,11 +92,11 @@ final class Client
     /**
      * Valides the phone number against the client country.
      *
-     * @param  integer $phoneNumber
+     * @param  string $phoneNumber // FIX: Accepts string instead of int
      *
      * @return boolean
      */
-    private function validatePhoneNumber(int $phoneNumber): bool
+    private function validatePhoneNumber(string $phoneNumber): bool
     {
         try {
             if (empty($phoneNumber)) {

--- a/src/modules/addons/lknhooknotification/src/Core/Shared/Infrastructure/helpers.php
+++ b/src/modules/addons/lknhooknotification/src/Core/Shared/Infrastructure/helpers.php
@@ -113,7 +113,7 @@ I18n::getInstance()::load(define_i18n_lang());
  */
 function lkn_hn_lang(array|string $text, array|Smarty_Internal_Template $params = []): string
 {
-    $key = is_array($text) ? $text['text'] : $text;
+    $key = is_array($text) ? ($text['text'] ?? '') : $text;
 
     if (empty($key)) {
         return '[empty]';
@@ -121,7 +121,11 @@ function lkn_hn_lang(array|string $text, array|Smarty_Internal_Template $params 
 
     $translated = I18n::getInstance()->get($key);
 
-    $params = is_array($text) ? $text['params'] : $params;
+    $params = is_array($text) ? ($text['params'] ?? []) : $params;
+
+    if (!is_iterable($params)) {
+        $params = [];
+    }
 
     foreach ($params as $key => $value) {
         $key_       = $key;

--- a/src/modules/addons/lknhooknotification/src/Core/Shared/Infrastructure/helpers.php
+++ b/src/modules/addons/lknhooknotification/src/Core/Shared/Infrastructure/helpers.php
@@ -221,7 +221,7 @@ function lkn_hn_config_set(Platforms $platform, Settings $setting, $value)
 
     lkn_hn_log(
         'Upsert setting',
-        ['setting' => $setting->name, 'value' > $value],
+        ['setting' => $setting->name, 'value' => $value],
         ['result' > $result]
     );
 }

--- a/src/modules/addons/lknhooknotification/src/Notifications/SafePasswordResetNotification.php
+++ b/src/modules/addons/lknhooknotification/src/Notifications/SafePasswordResetNotification.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Lkn\HookNotification\Notifications\Custom;
+
+use Lkn\HookNotification\Core\Notification\Domain\AbstractNotification;
+use Lkn\HookNotification\Core\Notification\Domain\NotificationParameter;
+use Lkn\HookNotification\Core\Notification\Domain\NotificationParameterCollection;
+
+final class SafePasswordResetNotification extends AbstractNotification
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'SafePasswordReset',
+            null,
+            null,
+            new NotificationParameterCollection([
+                new NotificationParameter(
+                    'password_reset_url',
+                    lkn_hn_lang('Password reset URL'),
+                    fn (): string => get_passsword_reset_url_for_user($this->whmcsHookParams['client_user_owner_email'])
+                ),
+                new NotificationParameter(
+                    'password_reset_token',
+                    lkn_hn_lang('Password reset token'),
+                    fn (): string => get_user_password_reset_token_by_user_email($this->whmcsHookParams['client_user_owner_email'])
+                ),
+                new NotificationParameter(
+                    'client_id',
+                    lkn_hn_lang('Client ID'),
+                    fn (): int => $this->client->id
+                ),
+                new NotificationParameter(
+                    'client_email',
+                    lkn_hn_lang('Client email'),
+                    fn (): string => getClientEmailByClientId($this->client->id)
+                ),
+                new NotificationParameter(
+                    'client_first_name',
+                    lkn_hn_lang('Client first name'),
+                    fn (): string => getClientFirstNameByClientId($this->client->id)
+                ),
+                new NotificationParameter(
+                    'client_full_name',
+                    lkn_hn_lang('Client full name'),
+                    fn (): string => getClientFullNameByClientId($this->client->id)
+                ),
+            ]),
+            fn() => $this->whmcsHookParams['client_id'],
+            description: 'This notification also affect the password reset page by using the existing recovery token in case its not expired yet. It avois sending multiple emails with different recovery tokens. The notification pass reset_password_url on the Password Reset Validation email template. (Tested on Twenty One theme)',
+        );
+    }
+}

--- a/src/modules/addons/lknhooknotification/src/Notifications/ServiceSuspendedFor45DaysNotification.php
+++ b/src/modules/addons/lknhooknotification/src/Notifications/ServiceSuspendedFor45DaysNotification.php
@@ -21,7 +21,7 @@ final class ServiceSuspendedFor45DaysNotification extends AbstractCronNotificati
     {
         parent::__construct(
             'ServiceSuspendedFor45Days',
-            NotificationReportCategory::ORDER,
+            NotificationReportCategory::SERVICE,
             Hooks::DAILY_CRON_JOB,
             new NotificationParameterCollection([
                 new NotificationParameter(
@@ -65,15 +65,15 @@ final class ServiceSuspendedFor45DaysNotification extends AbstractCronNotificati
         $suspendedServices = Capsule::table('tblhosting')
             ->leftJoin('tblproducts', 'tblproducts.id', '=', 'tblhosting.packageid')
             ->where('tblhosting.nextduedate', $formattedDate)
-            ->wherein('tblhosting.domainstatus', ['Suspended','Cancelled'])
+            ->whereIn('tblhosting.domainstatus', ['Suspended','Cancelled'])
             ->whereIn('tblproducts.type', ['hostingaccount', 'other'])
-            ->get(['tblhosting.id as serviceId', 'tblhosting.userid as clientId']);
+            ->get(['tblhosting.id', 'tblhosting.userid']);
             
         $payloads = [];
 
         foreach ($suspendedServices as $service) {
-            $serviceId = $service->serviceId;
-            $clientId  = $service->clientId;
+            $serviceId = $service->id;
+            $clientId  = $service->userid;
 
             $payloads[] = [
                 'client_id' => $clientId,

--- a/src/modules/addons/lknhooknotification/src/Notifications/UserPasswordChangeConfirmedNotication.php
+++ b/src/modules/addons/lknhooknotification/src/Notifications/UserPasswordChangeConfirmedNotication.php
@@ -40,7 +40,7 @@ final class UserPasswordChangeConfirmedNotication extends AbstractNotification
         );
     }
 
-    private function getClientId(int $userId){
-        return Capsule::table('tblusers_clients')->where('auth_user_id', $userId)->value('clien_id');
+    protected function getClientId(int $userId){
+        return Capsule::table('tblusers_clients')->where('auth_user_id', $userId)->value('client_id');
     }
 }


### PR DESCRIPTION
This pull request introduces several important fixes and improvements across the bulk messaging and notification modules, with a focus on phone number handling, locale filtering, notification payloads, and the addition of a new notification type. The changes enhance data consistency, improve filtering logic, and address several bugs related to data types and query construction.

**Phone Number Handling and Data Consistency:**

* Changed properties and methods in `Client` domain to use `string` instead of `int` for phone numbers, removed unnecessary type casting, and updated validation methods to support strings. This prevents errors and ensures proper handling of phone numbers with special characters. [[1]](diffhunk://#diff-e7eebdf49f30a105f512b51bb6684eed48a1b2749cdeb1b198ab6a004924fd3eL13-R15) [[2]](diffhunk://#diff-e7eebdf49f30a105f512b51bb6684eed48a1b2749cdeb1b198ab6a004924fd3eL31-R48) [[3]](diffhunk://#diff-e7eebdf49f30a105f512b51bb6684eed48a1b2749cdeb1b198ab6a004924fd3eL51-R63) [[4]](diffhunk://#diff-e7eebdf49f30a105f512b51bb6684eed48a1b2749cdeb1b198ab6a004924fd3eL68-R76) [[5]](diffhunk://#diff-e7eebdf49f30a105f512b51bb6684eed48a1b2749cdeb1b198ab6a004924fd3eL87-R99)

**Bulk Messaging Filtering and Logic:**

* Improved locale filtering in `getClientsByFilter` to correctly handle "default" values and empty locales, ensuring clients with unset or empty language are included as expected.
* Updated template logic in `edit_create_bulk.tpl` to properly select the "Default" option when no locale is set, improving user experience in the bulk messaging UI.
* Removed usage of undefined `$clientIds` variable in `createBulk`, preventing fatal errors during bulk creation.

**Notification System Enhancements:**

* Added a new notification type `SafePasswordResetNotification` to securely handle password reset notifications, using existing recovery tokens and providing relevant client information.
* Fixed notification payload construction in `ServiceSuspendedFor45DaysNotification` by correcting field names and category assignment, ensuring accurate reporting and compatibility with WHMCS schema. [[1]](diffhunk://#diff-ef99a699b8039a022dff5fe223a02dc1e6c076dd9d18e215181c0b325f1b5ee6L24-R24) [[2]](diffhunk://#diff-ef99a699b8039a022dff5fe223a02dc1e6c076dd9d18e215181c0b325f1b5ee6L68-R76)
* Corrected client ID retrieval in `UserPasswordChangeConfirmedNotication` to use the proper column name, addressing a bug in the notification logic.

**Shared Helper Functions:**

* Improved robustness in `lkn_hn_lang` helper by using null coalescing and checking for iterability, preventing errors when translation parameters are missing or malformed.
* Fixed logging typo in `lkn_hn_config_set` to use the correct array key syntax.

**Documentation Update:**

* Removed outdated IonCube requirement from `README.md`, clarifying system prerequisites.